### PR TITLE
Fixing blank switch buttons on small screens

### DIFF
--- a/htdocs/public/less/all.less
+++ b/htdocs/public/less/all.less
@@ -1,3 +1,4 @@
+@import "colors";
 @import "normalize";
 @import "fonts";
 @import "main";

--- a/htdocs/public/less/colors.less
+++ b/htdocs/public/less/colors.less
@@ -1,0 +1,1 @@
+@border-color: rgba(170, 170, 170, 1);

--- a/htdocs/public/less/dashboard.less
+++ b/htdocs/public/less/dashboard.less
@@ -10,6 +10,22 @@
   }
 }
 
+@media only screen and (max-width: 480px) {
+  .widget-small {
+    width: 100%;
+    float: none;
+    clear: both;
+    border-radius: inherit;
+    border-bottom: 1px solid @border-color;
+
+    .box-shadow(none);
+
+    &:first-child {
+      border-top: 1px solid @border-color;
+    }
+  }
+}
+
 @media only screen and (min-width: 480px) {
   .widgets {
     margin: 2.7% auto 2% auto;

--- a/htdocs/public/less/mixins.less
+++ b/htdocs/public/less/mixins.less
@@ -1,3 +1,9 @@
+.box-shadow (@string) {
+  -webkit-box-shadow: @string;
+  -moz-box-shadow: @string;
+  box-shadow: @string;
+}
+
 .widget {
   display: inline-block;
   float: left;


### PR DESCRIPTION
This is an attempt to restyle the switch styles on a small screen.
The old styling caused the button to disappear, this brings it back
and makes it full screen width.

This is what it looked like before:
<img src="https://cloud.githubusercontent.com/assets/545898/2786910/7a87e898-cb80-11e3-8ea4-abb14c86b64a.png" width="250">

With style changes:
<img src="https://cloud.githubusercontent.com/assets/545898/2786911/7a8835d2-cb80-11e3-802a-1b514f48886e.png" width="250">
