### PR TITLE
Adding a router layer to web requests

### DIFF
--- a/apitests/package.json
+++ b/apitests/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "should": "~2.1.0",
     "mocha": "~1.14.0",
-    "request": "~2.27.0"
+    "request": "~2.27.0",
+    "underscore": "*"
   }
 }

--- a/apitests/router_test.js
+++ b/apitests/router_test.js
@@ -1,0 +1,83 @@
+var request = require("request");
+var should = require("should");
+var assert = require("assert");
+
+// HACK: router.js needs this to work :(
+var _ = require("underscore");
+module.exports = {
+  '_': _
+};
+
+var Router = require("../router");
+
+describe("Router", function () {
+  it("supports proper namespacing", function () {
+    var handler = function() {},
+        router,
+        matched;
+
+    router = new Router("/v1"),
+    router.addRoute("GET", "/foo/bar", handler);
+    matched = router.dispatch("GET", "/v1/foo/bar");
+    assert.equal(matched.handler, handler);
+
+    router = new Router("/v3");
+    router.addRoute("GET", "/foo/bar", handler);
+    matched = router.dispatch("GET", "/v3/foo/bar");
+    assert.equal(matched.handler, handler);
+  });
+
+  it("supports simple paths", function () {
+    var handler1 = function() {},
+        handler2 = function() {},
+        handler3 = function() {},
+        router,
+        matched;
+
+    router = new Router("/v1"),
+    router.addRoute("GET", "/", handler1);
+    router.addRoute("GET", "/foo/bar", handler2);
+    router.addRoute("PUT", "/foo/bar/baz", handler3);
+
+    matched = router.dispatch("GET", "/v1/");
+    assert.equal(matched.handler, handler1);
+
+    matched = router.dispatch("GET", "/v1/foo/bar");
+    assert.equal(matched.handler, handler2);
+
+    matched = router.dispatch("GET", "/v1/foo/bar/baz");
+    assert.equal(matched, undefined);
+
+    matched = router.dispatch("PUT", "/v1/foo/bar/baz");
+    assert.equal(matched.handler, handler3);
+  });
+
+  it("supports patterned paths", function () {
+    var handler1 = function() {},
+        handler2 = function() {},
+        handler3 = function() {},
+        router,
+        matched;
+
+    router = new Router("/v1"),
+    router.addRoute("GET", "/foo/:bar", handler1);
+    router.addRoute("GET", "/:foo/bar", handler2);
+    router.addRoute("PUT", "/:foo/bar/:baz", handler3);
+
+    matched = router.dispatch("GET", "/v1/");
+    assert.equal(matched, undefined);
+
+    matched = router.dispatch("GET", "/v1/foo/abcde");
+    assert.equal(matched.handler, handler1);
+    assert.deepEqual(matched.params, ["abcde"]);
+
+    matched = router.dispatch("GET", "/v1/whoaman/bar");
+    assert.equal(matched.handler, handler2);
+    assert.deepEqual(matched.params, ["whoaman"]);
+
+    matched = router.dispatch("PUT", "/v1/first_param/bar/second_param");
+    assert.equal(matched.handler, handler3);
+    assert.deepEqual(matched.params, ["first_param", "second_param"]);
+  });
+});
+

--- a/router.js
+++ b/router.js
@@ -1,0 +1,97 @@
+// Make this testable by pulling in underscore from the parent module
+if (typeof _ === "undefined" && typeof module !== "undefined" && module.parent) {
+  var _ = module.parent.exports._;
+}
+
+Router = function(namespace) {
+  this.routes = {};
+  this.namespace = namespace || "/v1";
+};
+
+Router.prototype = {
+  get: function(path, handler) {
+    return this.addRoute("GET", path, handler);
+  },
+
+  post: function(path, handler) {
+    return this.addRoute("POST", path, handler);
+  },
+
+  put: function(path, handler) {
+    return this.addRoute("PUT", path, handler);
+  },
+
+  addRoute: function(method, path, handler) {
+    var ns = this.routes[this.namespace] = this.routes[this.namespace] || {},
+        route;
+
+    ns[method] = ns[method] || {};
+
+    if (ns[method][path]) {
+      console.error("Path already registered, ignoring...");
+      return;
+    }
+
+    if (_.contains(path, ":")) {
+      var route = this._parseRoute(path);
+      ns[method].patterns = ns[method].patterns || []; 
+      ns[method].patterns.push(_.extend(route, {handler: handler}));
+    } else {
+      ns[method][path] = handler;
+    }
+
+    return this;
+  },
+
+  /**
+   * The assumption that we only support :variable_format, we will only check
+   * for alphanumeric and underscores.
+   */
+  _parseRoute: function(path) {
+    var parts = path.split("/"),
+        parameters = [];
+
+    var pattern = _.map(parts, function(segment) {
+      if (segment.length && segment[0] === ":") {
+        // Keep track of the parameters we've replaced
+        parameters.push(segment.slice(1));
+        return "(.+)";
+      }
+      return segment;
+    }).join("/");
+
+    return {params: parameters, pattern: new RegExp(pattern)};
+  },
+
+  dispatch: function(method, url) {
+    var parts = url.split("/"),
+        namespace = _.first(parts, 2).join("/"),
+        path = "/" + _.rest(parts, 2).join("/"),
+        lookup, handler, params;
+
+    var ns = this.routes[namespace];
+    if (ns && ns[method]) {
+      handler = ns[method][path];
+      if (handler) {
+        return {handler: handler, params: []};
+      } else {
+        _.find(ns[method].patterns, function(r) {
+          var matches = r.pattern.exec(path);
+          if (!!matches) {
+            params = matches.slice(1);
+            handler = r.handler;
+            return true;
+          }
+        });
+
+        if (params && handler) {
+          return {handler: handler, params: params};
+        }
+      }
+    }
+  }
+};
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = Router;
+};


### PR DESCRIPTION
NOTE: I'm not sure what the coding standard is, let me know so
I can change my stuff.

This is hopefully to simplify future additions of routes to the API.
If we had a more comprehensive set of routes, it may make sense to
switch to a library for route handling. Otherwise this is a simple
replacement that aims to keep backwards compatibility with the
existing routes.

At the moment, the router supports both the simple paths and the
patterned paths. A simple match returns:

```
{
  handler: handlerFunc,
  params: []
}
```

On the other hand, the patterned matcher returns the handler function
and the matched URL parameters, so if we define a url as:

```
/foo/:param1/bar/:param2
```

The matched route for /foo/abcde/bar/hijkl would be:

```
{
  handler: handlerFunc,
  params: ["abcde", "hijkl"]
}
```
