### PR TITLE
Clean up popup styling a little bit

### DIFF
--- a/htdocs/public/less/main.less
+++ b/htdocs/public/less/main.less
@@ -794,7 +794,7 @@ input[type='range']::-moz-focusring {
 
 .rooms-icon { background-position: -0px -0px; width: 51px; height: 51px; }
 .battery-icon { background-position: -0px -51px; width: 50px; height: 25px; }
-.general-icon { background-position: -0px -76px; width: 50px; height: 49px; }
+.general-icon { background-position: -0px -77px; width: 50px; height: 48px; }
 .switch-icon { background-position: -0px -125px; width: 50px; height: 30px; }
 .notifications-icon { background-position: -0px -155px; width: 46px; height: 50px; }
 .modules-icon { background-position: -0px -205px; width: 44px; height: 51px; }

--- a/htdocs/public/less/popup.less
+++ b/htdocs/public/less/popup.less
@@ -1,3 +1,5 @@
+@popover-title-height: 60px;
+
 @border-width: 3px;
 @border-position: 4px;
 .popover {
@@ -194,7 +196,7 @@
   background-color: #ededed;
   .top-popover-container {
     background-color: #283236;
-    height: 60px;
+    height: @popover-title-height;
     display: block;
     float: left;
     width: 100%;
@@ -219,6 +221,21 @@
       cursor: pointer;
       font-size: 13px;
     }
+
+    .back-button {
+      vertical-align: baseline;
+      font-size: 20px;
+      transform: scale(2,1);
+      -webkit-transform: scale(1,2);
+      -moz-transform: scale(2,1);
+      -ms-transform: scale(2,1);
+      -o-transform: scale(2,1);
+    }
+
+    .close-button {
+      font-size: 20px;
+    }
+
     &.right {
       float: right;
     }
@@ -236,7 +253,7 @@
       margin: 0;
       font-weight: normal;
       font-size: 18px;
-      line-height: 34px;
+      line-height: @popover-title-height;
       vertical-align: middle;
       color: #fff;
       height: 34px;
@@ -452,6 +469,7 @@
           width: 50px;
           height: 60px;
           line-height: 60px;
+          opacity: 0.7;
           .container-icon {
             display: inline-block;
             vertical-align: middle;
@@ -464,6 +482,12 @@
           vertical-align: bottom;
           width: 100%;
           opacity: 0.6;
+        }
+
+        &:hover {
+          .icon-span {
+            opacity: 1.0;
+          }
         }
       }
     }

--- a/htdocs/templates/popups/preferences-menu.html
+++ b/htdocs/templates/popups/preferences-menu.html
@@ -1,7 +1,7 @@
 <div class="popover popover-type-general popover-preferences">
     <div class="top-popover-container">
         <div class="button-container left">
-            <span class="button-inline back-button">back</span>
+            <span class="button-inline back-button">&lt;</span>
         </div>
         <div class="center-container">
             <span class="title">Menu</span>
@@ -17,7 +17,7 @@
             </ul>
         </div>
         <div class="button-container right">
-            <span class="button-inline close-button">x</span>
+            <span class="button-inline close-button">&#10005;</span>
         </div>
     </div>
     <div class="popover-content">


### PR DESCRIPTION
- The menu title is now vertically aligned in the popup
- "back" text is replaced with a &lt; symbol
- Use a multiply unicode character for close symbol
- Made the back/close button a little bit bigger
- Gave the menu-list icons a little hover feedback

Before change:
<img src="https://cloud.githubusercontent.com/assets/545898/2872331/660942e0-d35a-11e3-80e3-43d8a448dc9f.png" width=600/>

After change:
<img src="https://cloud.githubusercontent.com/assets/545898/2872334/84d9eff8-d35a-11e3-8c18-8e9e07a32464.png" width=600/>

It is hard to tell, but the widget icon is slightly darker than the other icons due to it having full opacity. It's to give a slightly better feel for UX.
