### PR TITLE
Adding a router layer to web requests

### DIFF
--- a/apitests/package.json
+++ b/apitests/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "should": "~2.1.0",
     "mocha": "~1.14.0",
-    "request": "~2.27.0"
+    "request": "~2.27.0",
+    "underscore": "*"
   }
 }

--- a/apitests/router_test.js
+++ b/apitests/router_test.js
@@ -1,0 +1,119 @@
+var request = require("request");
+var should = require("should");
+var assert = require("assert");
+
+// HACK: router.js needs this to work :(
+var _ = require("underscore");
+module.exports = {
+  '_': _
+};
+
+var Router = require("../router");
+
+describe("Router", function () {
+  it("supports proper namespacing", function () {
+    var handler = function() {},
+        router,
+        matched;
+
+    router = new Router("/v1"),
+    router.addRoute("GET", "/foo/bar", handler);
+    matched = router.dispatch("GET", "/v1/foo/bar");
+    assert.equal(matched.handler, handler);
+
+    router = new Router("/v3");
+    router.addRoute("GET", "/foo/bar", handler);
+    matched = router.dispatch("GET", "/v3/foo/bar");
+    assert.equal(matched.handler, handler);
+  });
+
+  it("supports simple paths", function () {
+    var handler1 = function() {},
+        handler2 = function() {},
+        handler3 = function() {},
+        router,
+        matched;
+
+    router = new Router("/v1"),
+    router.addRoute("GET", "/", handler1);
+    router.addRoute("GET", "/foo/bar", handler2);
+    router.addRoute("PUT", "/foo/bar/baz", handler3);
+
+    matched = router.dispatch("GET", "/v1/");
+    assert.equal(matched.handler, handler1);
+
+    matched = router.dispatch("GET", "/v1/foo/bar");
+    assert.equal(matched.handler, handler2);
+
+    matched = router.dispatch("GET", "/v1/foo/bar/baz");
+    assert.equal(matched, undefined);
+
+    matched = router.dispatch("PUT", "/v1/foo/bar/baz");
+    assert.equal(matched.handler, handler3);
+  });
+
+  it("supports patterned paths", function () {
+    var handler1 = function() { console.log('1'); },
+        handler2 = function() { console.log('2'); },
+        handler3 = function() { console.log('3'); },
+        handler4 = function() { console.log('4'); },
+        handler5 = function() { console.log('5'); },
+        handler6 = function() { console.log('6'); },
+        router,
+        matched;
+
+    router = new Router("/v1"),
+    router.addRoute("GET", "/foo/:bar", handler1);
+    router.addRoute("GET", "/:foo/bar", handler2);
+    router.addRoute("GET", "/far/:baz", handler3);
+    router.addRoute("DELETE", "/far/:baz", handler4);
+    router.addRoute("POST", "/far/:baz", handler5);
+    router.addRoute("PUT", "/far/:baz", handler6);
+
+    matched = router.dispatch("GET", "/v1/");
+    assert.equal(matched, undefined);
+
+    matched = router.dispatch("GET", "/v1/foo/abcde");
+    assert.equal(matched.handler, handler1);
+    assert.deepEqual(matched.params, ["abcde"]);
+
+    matched = router.dispatch("GET", "/v1/whoaman/bar");
+    assert.equal(matched.handler, handler2);
+    assert.deepEqual(matched.params, ["whoaman"]);
+
+    matched = router.dispatch("GET", "/v1/far/second_param");
+    assert.equal(matched.handler, handler3);
+    assert.deepEqual(matched.params, ["second_param"]);
+    matched = router.dispatch("DELETE", "/v1/far/second_param");
+    assert.equal(matched.handler, handler4);
+    assert.deepEqual(matched.params, ["second_param"]);
+    matched = router.dispatch("POST", "/v1/far/second_param");
+    assert.equal(matched.handler, handler5);
+    assert.deepEqual(matched.params, ["second_param"]);
+    matched = router.dispatch("PUT", "/v1/far/second_param");
+    assert.equal(matched.handler, handler6);
+    assert.deepEqual(matched.params, ["second_param"]);
+  });
+
+  it("supports patterned paths with preprocessors", function () {
+    var handler1 = function() { console.log('1'); },
+        handler2 = function() { console.log('2'); },
+        router,
+        matched;
+
+    router = new Router("/v1"),
+    router.addRoute("GET", "/foo/:bar/:baz", handler1, [parseInt]);
+    router.addRoute("GET", "/fob/:foo/:bar", handler1, [null, parseInt]);
+
+    matched = router.dispatch("GET", "/v1/foo/12/123");
+    assert.equal(matched.handler, handler1);
+    assert.strictEqual(matched.params[0], 12);
+    assert.strictEqual(matched.params[1], "123");
+
+    matched = router.dispatch("GET", "/v1/fob/12/123");
+    assert.equal(matched.handler, handler1);
+    assert.strictEqual(matched.params[0], "12");
+    assert.strictEqual(matched.params[1], 123);
+  });
+});
+

--- a/router.js
+++ b/router.js
@@ -1,0 +1,107 @@
+// Make this testable by pulling in underscore from the parent module
+if (typeof _ === "undefined" && typeof module !== "undefined" && module.parent) {
+  var _ = module.parent.exports._;
+}
+
+Router = function(namespace) {
+  this.routes = {};
+  this.namespace = namespace || "/v1";
+};
+
+Router.prototype = {
+  get: function(path, handler, preprocessors) {
+    return this.addRoute("GET", path, handler, preprocessors);
+  },
+
+  post: function(path, handler, preprocessors) {
+    return this.addRoute("POST", path, handler, preprocessors);
+  },
+
+  put: function(path, handler, preprocessors) {
+    return this.addRoute("PUT", path, handler, preprocessors);
+  },
+
+  del: function(path, handler, preprocessors) {
+    return this.addRoute("DELETE", path, handler, preprocessors);
+  },
+
+  addRoute: function(method, path, handler, preprocessors) {
+    var ns = this.routes[this.namespace] = this.routes[this.namespace] || {},
+        preprocessors = preprocessors || [],
+        route;
+
+    ns[method] = ns[method] || {};
+
+    if (ns[method][path]) {
+      console.error("Path already registered, ignoring...");
+      return;
+    }
+
+    if (_.contains(path, ":")) {
+      var route = this._parseRoute(path, preprocessors);
+      ns[method].patterns = ns[method].patterns || []; 
+      ns[method].patterns.push(_.extend(route, {handler: handler, preprocessors: preprocessors}));
+    } else {
+      ns[method][path] = {handler: handler, preprocessors: preprocessors};
+    }
+
+    return this;
+  },
+
+  /**
+   * The assumption that we only support :variable_format, we will only check
+   * for alphanumeric and underscores.
+   */
+  _parseRoute: function(path, preprocessors) {
+    var parts = path.split("/"),
+        parameters = [];
+
+    var pattern = _.map(parts, function(segment) {
+      if (segment.length && segment[0] === ":") {
+        // Keep track of the parameters we've replaced
+        parameters.push(segment.slice(1));
+        return "(.+)";
+      }
+      return segment;
+    }).join("/");
+
+    return {params: parameters, pattern: new RegExp(pattern)};
+  },
+
+  dispatch: function(method, url) {
+    var parts = url.split("/"),
+        namespace = _.first(parts, 2).join("/"),
+        path = "/" + _.rest(parts, 2).join("/"),
+        lookup, handler, params, preprocessors;
+
+    var ns = this.routes[namespace];
+    if (ns && ns[method]) {
+      handler = ns[method][path];
+      if (handler) {
+        return {handler: handler.handler, params: []};
+      } else {
+        _.find(ns[method].patterns, function(r) {
+          var matches = r.pattern.exec(path);
+          if (!!matches) {
+            params = matches.slice(1);
+            handler = r.handler;
+            preprocessors = r.preprocessors;
+            return true;
+          }
+        });
+
+        if (params && handler) {
+          params = _.map(params, function(param, i) {
+              var proc = preprocessors[i] || _.identity;
+              return proc(param);
+          });
+          return {handler: handler, params: params};
+        }
+      }
+    }
+  }
+};
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = Router;
+};

--- a/webserver.js
+++ b/webserver.js
@@ -11,9 +11,12 @@ Copyright: (c) ZWave.Me, 2013
 // --- ZAutomationAPIWebRequest
 // ----------------------------------------------------------------------------
 
+executeFile("router.js");
+
 function ZAutomationAPIWebRequest (controller) {
     ZAutomationAPIWebRequest.super_.call(this);
 
+    this.router = new Router("/v1");
     this.controller = controller;
     this.res = {
         status: 200,
@@ -22,11 +25,62 @@ function ZAutomationAPIWebRequest (controller) {
         },
         body: null
     };
+
+    this.registerRoutes();
 };
 
+var ZAutomationWebRequest = ZAutomationWebRequest || function() {};
 inherits(ZAutomationAPIWebRequest, ZAutomationWebRequest);
 
 _.extend(ZAutomationAPIWebRequest.prototype, {
+    registerRoutes: function() {
+        this.router.get("/status", this.statusReport);
+        this.router.get("/notifications", this.exposeNotifications());
+        this.router.get("/devices", this.listDevices);
+        this.router.get("/restart", this.restartController);
+        this.router.get("/locations", this.listLocations());
+        this.router.get("/profiles", this.listProfiles());
+        this.router.get("/namespaces", this.listNamespaces);
+        this.router.get("/profiles", this.createProfile());
+        this.router.get("/locations/add", this.addLocation());
+        this.router.post("/locations", this.addLocation());
+        this.router.get("/locations/remove", this.removeLocation());
+        this.router.get("/locations/update", this.updateLocation());
+        this.router.get("/modules", this.listModules);
+        this.router.get("/instances", this.listInstances);
+        this.router.post("/instances", this.createInstance());
+        this.router.get("/schemas", this.listSchemas);
+
+        // TODO: Should we remove these as they are no longer available?
+        // this.router.post("/namespaces", this.createNamespace());
+        // this.router.get("/notifications/markRead", this.markNotificationsRead());
+        // this.router.post("/schemas", this.createSchema());
+
+        // patterned routes, right now we are going to just send in the wrapper
+        // function. We will let the handler consumer handle the application of
+        // the parameters.
+        this.router.get("/devices/:v_dev_id/command/:command_id", this.performVDevCommandFunc);
+
+        this.router.del("/locations/:location_id", this.removeLocation, [parseInt]);
+        this.router.put("/locations/:location_id", this.updateLocation, [parseInt]);
+        this.router.get("/locations/:location_id", this.listLocations, [parseInt]);
+
+        this.router.put("/notifications/:notification_id", this.updateNotification, [parseInt]);
+        this.router.get("/notifications/:notification_id", this.getNotificationFunc, [parseInt]);
+
+        this.router.del("/profiles/:profile_id", this.removeProfile, [parseInt]);
+        this.router.put("/profiles/:profile_id", this.updateProfile, [parseInt]);
+        this.router.get("/profiles/:profile_id", this.listProfiles, [parseInt]);
+
+        this.router.put("/devices/:dev_id", this.setVDevFunc);
+        this.router.get("/devices/:dev_id", this.getVDevFunc);
+
+        this.router.get("/instances/:instance_id", this.getInstanceFunc, [parseInt]);
+        this.router.put("/instances/:instance_id", this.reconfigureInstanceFunc, [parseInt]);
+        this.router.del("/instances/:instance_id", this.deleteInstanceFunc, [parseInt]);
+
+        this.router.get("/namespaces/:namespace_id", this.getNamespaceFunc, [parseInt]);
+    },
     statusReport: function () {
         var reply = {
             error: null,
@@ -686,150 +740,21 @@ _.extend(ZAutomationAPIWebRequest.prototype, {
 
 ZAutomationAPIWebRequest.prototype.dispatchRequest = function (method, url) {
     // Default handler is NotFound
-    var handlerFunc = this.NotFound;
+    var handlerFunc = this.NotFound,
+        validParams;
 
-    // ---------- Test exact URIs ---------------------------------------------
-
-    if ("GET" === method && "/v1/status" === url) {
-        handlerFunc = this.statusReport;
-    } else if ("GET" === method && "/v1/notifications" === url) {
-        handlerFunc = this.exposeNotifications();
-    } else if ("GET" === method && "/v1/notifications/markRead" === url) {
-        handlerFunc = this.markNotificationsRead();
-    } else if ("GET" === method && "/v1/devices" === url) {
-        handlerFunc = this.listDevices;
-    } else if ("GET" === method && "/v1/restart" === url) {
-        handlerFunc = this.restartController;
-    } else if ("GET" === method && "/v1/locations" === url) {
-        handlerFunc = this.listLocations();
-    } else if ("GET" === method && "/v1/profiles" === url) {
-        handlerFunc = this.listProfiles();
-    } else if ("GET" === method && "/v1/namespaces" === url) {
-        handlerFunc = this.listNamespaces;
-    } else if (("POST" === method) && "/v1/namespaces" === url) {
-        handlerFunc = this.createNamespace();
-    } else if (("POST" === method) && "/v1/profiles" === url) {
-        handlerFunc = this.createProfile();
-    } else if (("GET" === method && "/v1/locations/add" === url) || ("POST" === method && "/v1/locations" === url)) {
-        handlerFunc = this.addLocation();
-    } else if ("GET" === method && "/v1/locations/remove" === url) {
-        handlerFunc = this.removeLocation();
-    } else if ("GET" === method && "/v1/locations/update" === url) {
-        handlerFunc = this.updateLocation();
-    } else if ("GET" === method && "/v1/modules" === url) {
-        handlerFunc = this.listModules;
-    } else if ("GET" === method && "/v1/instances" === url) {
-        handlerFunc = this.listInstances;
-    } else if (("POST" === method) && "/v1/instances" === url) {
-        handlerFunc = this.createInstance();
-    } else if ("GET" === method && "/v1/schemas" === url) {
-        handlerFunc = this.listSchemas;
-    } else if ("POST" === method && "/v1/schemas" === url) {
-        handlerFunc = this.createSchema();
-    } else if ("OPTIONS" === method) {
+    if ("OPTIONS" === method) {
         handlerFunc = this.CORSRequest;
-    };
-
-    // ---------- Test regexp URIs --------------------------------------------
-    var re, reTest;
-
-    // --- Perform vDev command
-    if (handlerFunc === this.NotFound) {
-        re = /\/v1\/devices\/(.+)\/command\/(.+)/;
-        reTest = re.exec(url);
-        if (!!reTest) {
-            var vDevId = reTest[1];
-            var commandId = reTest[2];
-            if ("GET" === method && !!vDevId && !!commandId && controller.devices.get(vDevId)) {
-                handlerFunc = this.performVDevCommandFunc(vDevId, commandId);
-            }
-        }
-    }
-
-    // --- Remove and Update location
-    if (handlerFunc === this.NotFound) {
-        re = /\/v1\/locations\/(.+)/;
-        reTest = re.exec(url);
-        if (!!reTest) {
-            var locationId = parseInt(reTest[1]);
-            if ("DELETE" === method && locationId) {
-                handlerFunc = this.removeLocation(locationId);
-            } else if ("PUT" === method && locationId) {
-                handlerFunc = this.updateLocation(locationId);
-            } else if ("GET" === method && locationId) {
-                handlerFunc = this.listLocations(locationId);
-            }
-        }
-    }
-
-    // --- Remove and Update notifications
-    if (handlerFunc === this.NotFound) {
-        re = /\/v1\/notifications\/(.+)/;
-        reTest = re.exec(url);
-        if (!!reTest) {
-            var notificationId = parseInt(reTest[1]);
-            if ("PUT" === method && notificationId) {
-                handlerFunc = this.updateNotification(notificationId);
-            } else if ("GET" === method && notificationId) {
-                handlerFunc = this.getNotificationFunc(notificationId);
-            }
-        }
-    }
-
-    // --- Remove and Update profiles
-    if (handlerFunc === this.NotFound) {
-        re = /\/v1\/profiles\/(.+)/;
-        reTest = re.exec(url);
-        if (!!reTest) {
-            var profileId = parseInt(reTest[1]);
-            if ("DELETE" === method && profileId) {
-                handlerFunc = this.removeProfile(profileId);
-            } else if ("PUT" === method && profileId) {
-                handlerFunc = this.updateProfile(profileId);
-            } else if ("GET" === method && profileId) {
-                handlerFunc = this.listProfiles(profileId);
-            }
-        }
-    }
-
-    // --- Get and Set VDev meta
-    if (handlerFunc === this.NotFound) {
-        re = /\/v1\/devices\/(.+)/;
-        reTest = re.exec(url);
-        if (!!reTest) {
-            var vDevId = reTest[1];
-            if ("GET" === method && !!vDevId) {
-                handlerFunc = this.getVDevFunc(vDevId);
-            } else if ("PUT" === method && !!vDevId) {
-                handlerFunc = this.setVDevFunc(vDevId);
-            }
-        }
-    }
-
-    // --- Get instance config
-    if (handlerFunc === this.NotFound) {
-        re = /\/v1\/instances\/(.+)/;
-        reTest = re.exec(url);
-        if (!!reTest) {
-            var instanceId = parseInt(reTest[1]);
-            if ("GET" === method && !!instanceId) {
-                handlerFunc = this.getInstanceFunc(instanceId);
-            } else if ("PUT" === method && !!instanceId) {
-                handlerFunc = this.reconfigureInstanceFunc(instanceId);
-            } else if ("DELETE" === method && !!instanceId) {
-                handlerFunc = this.deleteInstanceFunc(instanceId);
-            }
-        }
-    }
-
-    // --- Get namespaces
-    if (handlerFunc === this.NotFound) {
-        re = /\/v1\/namespaces\/(.+)/;
-        reTest = re.exec(url);
-        if (!!reTest) {
-            var namespaceId = parseInt(reTest[1]);
-            if ("GET" === method && !!namespaceId) {
-                handlerFunc = this.getNamespaceFunc(namespaceId);
+    } else {
+        var matched = this.router.dispatch(method, url);
+        if (matched) {
+            if (matched.params.length) {
+                validParams = _.every(matched.params), function(p) { return !!p; };
+                if (validParams) {
+                    handlerFunc = matched.handler.apply(this, matched.params);
+                }
+            } else {
+                handlerFunc = matched.handler;
             }
         }
     }


### PR DESCRIPTION
This is hopefully to simplify future additions of routes to the API.
If we had a more comprehensive set of routes, it may make sense to
switch to a library for route handling. Otherwise this is a simple
replacement that aims to keep backwards compatibility with the
existing routes.

At the moment, the router supports both the simple paths and the
patterned paths. A simple match returns:

```
{
  handler: handlerFunc,
  params: []
}
```

On the other hand, the patterned matcher returns the handler function
and the matched URL parameters, so if we define a url as:

```
/foo/:param1/bar/:param2
```

The matched route for /foo/abcde/bar/hijkl would be:

```
{
  handler: handlerFunc,
  params: ["abcde", "hijkl"]
}
```
