### PR TITLE
Make switch button title editable on dashboard

### DIFF
--- a/htdocs/public/less/mixins.less
+++ b/htdocs/public/less/mixins.less
@@ -360,6 +360,16 @@
     overflow: hidden;
     display: block;
     float: left;
+
+
+    &[contenteditable="true"] {
+      border: 1px solid #cdcdcd;
+      box-sizing: border-box;
+      height: 47px;
+    }
+    &:focus {
+      text-overflow: inherit;
+    }
   }
   .border-widget {
     .selection-button {


### PR DESCRIPTION
This uses HTML5 for making the title of the switch editable. When
entering the "Rearrange and Settings" mode on the Dashboard, the
switch title becomes editable. On blur, the title is saved. There's
special handling of enter keys, since it does not make sense to have
newlines in the names, enter keys are interpreted as "saving."

Edit mode:
![screen shot 2014-05-08 at 12 58 03 am](https://cloud.githubusercontent.com/assets/545898/2913142/b0aada40-d687-11e3-9894-de18189ef11c.png)

Editing:
![screen shot 2014-05-08 at 12 58 53 am](https://cloud.githubusercontent.com/assets/545898/2913144/b7bd66ae-d687-11e3-9a4a-d37ffca3d0b1.png)

Saved/refreshed:
![screen shot 2014-05-08 at 12 59 07 am](https://cloud.githubusercontent.com/assets/545898/2913146/bdbaff8a-d687-11e3-9d63-776622433b9a.png)
