### PR TITLE
Fixed callback execution error on SwitchControlGenerator

### DIFF
--- a/modules/SwitchControlGenerator/index.js
+++ b/modules/SwitchControlGenerator/index.js
@@ -62,7 +62,7 @@ SwitchControlGenerator.prototype.init = function (config) {
                     self.handler(val, par, [dataB.srcNodeId.value, dataB.srcInstanceId.value, n]);
                 }, "");
                 controller.emit("ZWaveGate.dataBind", self.bindings, ctrlNodeId, n, self.CC["SwitchBinary"], "level", function(type) {
-                    self.handler(this.value ? "on" : "off", [dataSB.srcNodeId.value, dataSB.srcInstanceId.value, n]);
+                    self.handler(this.value ? "on" : "off", {}, [dataSB.srcNodeId.value, dataSB.srcInstanceId.value, n]);
                 }, "");
                 controller.emit("ZWaveGate.dataBind", self.bindings, ctrlNodeId, n, self.CC["SwitchMultilevel"], "level", function(type) {
                     var val, par = {};


### PR DESCRIPTION
Fixes a bug in log:

[2014-09-09 22:13:29.827] Callback execution error: TypeError: Cannot read property 'join' of undefined
    at SwitchControlGenerator.handler (automation/modules/SwitchControlGenerator/index.js:151:22)
    at ZDataHolder.<anonymous> (automation/modules/SwitchControlGenerator/index.js:65:26)
