### PR TITLE
fixed missing overlay in init

### DIFF
--- a/modules/SecurityMode/index.js
+++ b/modules/SecurityMode/index.js
@@ -51,6 +51,9 @@ SecurityMode.prototype.init = function (config) {
                     title: 'SecurityMode ' + this.id
                 }
             },
+            overlay: {
+            	deviceType: "switchBinary"
+        	},
             handler: function(command, args) {
                 this.set("metrics:level", command);
             },


### PR DESCRIPTION
before this fix, I always got the following error message when adding the SecurityMode in HA:

"Can not init module SecurityMode: TypeError: Cannot read property 'deviceType' of undefined"



