### PR TITLE
Allow a delay for running custom scripts after start up

### DIFF
--- a/modules/CustomUserCode/index.js
+++ b/modules/CustomUserCode/index.js
@@ -40,9 +40,13 @@ CustomUserCode.prototype.init = function (config) {
     if(self.timer) {
 	clearTimeout(self.timer);
     }
-    self.timer = setTimeout(function() {
+    if(self.config.delay > 0) {
+	self.timer = setTimeout(function() {
+	    self.timeoutHandler();
+	}, self.config.delay*1000);
+    } else {
 	self.timeoutHandler();
-    }, self.config.delay*1000);
+    }
     
 };
 

--- a/modules/CustomUserCode/index.js
+++ b/modules/CustomUserCode/index.js
@@ -31,16 +31,41 @@ CustomUserCode.prototype.init = function (config) {
     // Call superclass' init (this will process config argument and so on)
     CustomUserCode.super_.prototype.init.call(this, config);
 
-    // TODO: executeJS errors are impossible to catch!
-    //try {
-        executeJS(this.config.customCode);
-    //} catch (e) {
-    //    controller.addNotification("warning", "Failed to load custom user code: " + this.get("metrics:title"), "module");
-    //}
+    var self = this;
+
+    this.timer = null;
+
+    this.timeoutHandler = this.handler;
+
+    if(self.timer) {
+	clearTimeout(self.timer);
+    }
+    self.timer = setTimeout(function() {
+	self.timeoutHandler();
+    }, self.config.delay*1000);
+    
+};
+
+CustomUserCode.prototype.stop = function () {
+
+    if(this.timer) {
+	clearTimeout(this.timer);
+    }
+
+    this.timeoutHandler = function () {};
+
+    CustomUserCode.super_.prototype.stop.call(this);
 };
 
 // ----------------------------------------------------------------------------
 // --- Module methods
 // ----------------------------------------------------------------------------
 
-// This module has no additional methods
+CustomUserCode.prototype.handler = function() {
+    // TODO: executeJS errors are impossible to catch!
+    //try {
+        executeJS(this.config.customCode);
+    //} catch (e) {
+    //    controller.addNotification("warning", "Failed to load custom user code: " + this.get("metrics:title"), "module");
+    //}    
+};

--- a/modules/CustomUserCode/module.json
+++ b/modules/CustomUserCode/module.json
@@ -22,6 +22,10 @@
         "properties": {
             "customCode": {
                 "type": "string"
+	    },
+	    "delay": {
+                "type": "integer",
+                "minimum": 0
             }
         },
         "required": false
@@ -33,7 +37,11 @@
                 "type": "textarea",
                 "label": "Your JavaScript code:",
 		        "cols": 40
-            }
+            },
+            "delay": {
+                "label": "Delay in seconds",
+                "type": "integer"
+            }	    
         }
     }
 }


### PR DESCRIPTION
This can be useful for various purposes. Notably if you need to ensure everything has been initialized before you run your custom code.