### PR TITLE
Update index.js to make multiLevelSwitch a compliant dimmable, Siri controllable Lightbulb

### DIFF
--- a/modules/HomeKitGate/index.js
+++ b/modules/HomeKitGate/index.js
@@ -115,10 +115,15 @@ HomeKitGate.prototype.init = function (config) {
 			});
 		}
 		else if (deviceType == "switchMultilevel") {
-			var serviceUUID = "1004";
-		
-			var service = accessory.addService(serviceUUID, "Multilevel Switch");
-			
+			var serviceUUID = HomeKit.Services.Lightbulb;
+
+                        var service = accessory.addService(serviceUUID, title + " Dimmer");
+
+                        m.level = service.addCharacteristic(HomeKit.Characteristics.PowerState, "bool", {
+                                get: function() { return (parseFloat(vDev.get("metrics:level")) || 0.0)>0; },
+                                set: function(value) { vDev.performCommand(value ? "on" : "off"); }
+                        });
+
 			m.level = service.addCharacteristic(HomeKit.Characteristics.Brightness, "float", {
 				get: function() { return parseFloat(vDev.get("metrics:level")) || 0.0; },
 				set: function(value) { vDev.performCommand("exact", { level: value }); }


### PR DESCRIPTION
Change switchMultiLevel to be a type of light bulb, which is almost always what you want.  Compliant HomeKit lightbulbs MUST have the PowerState characteristic.  Note also that the second param of accessory.addService is used by HomeKit as the default device name for Siri.

This change facilitates:
- Siri control of dimmers (yay!!)
- Proper rendering as a Lightbulb in Insteon app, plus others