### PR TITLE
Fix problem getting weather in the United States

### DIFF
--- a/modules/OpenWeather/index.js
+++ b/modules/OpenWeather/index.js
@@ -78,7 +78,7 @@ OpenWeather.prototype.fetchExtendedWeather = function(instance) {
         lang = self.controller.defaultLang;
     
     http.request({
-        url: "http://api.openweathermap.org/data/2.5/weather?q=" + self.config.city + "," + self.config.country +"&lang=" + lang,
+        url: "http://api.openweathermap.org/data/2.5/weather?q=" + encodeURIComponent(self.config.city) + "," + encodeURIComponent(self.config.country) +"&lang=" + lang,
         async: true,
         success: function(res) {
             try {


### PR DESCRIPTION
Calling the api.openweathermap.org site without properly url encoding the parameters returns an 500 error:

$ curl -I "http://api.openweathermap.org/data/2.5/weather?q=Miami,United States&lang=en"
HTTP/1.1 500 Internal Server Error
Server: nginx
Date: Thu, 17 Sep 2015 00:53:49 GMT
Content-Type: text/html
Connection: keep-alive

Escaping the parameters works as expected:

$ curl -i "http://api.openweathermap.org/data/2.5/weather?q=Miami,United+States&lang=en"
HTTP/1.1 200 OK
Server: nginx
...