### PR TITLE
Prepare various login improvements for SmarthomeUI

### DIFF
--- a/ZAutomationAPIProvider.js
+++ b/ZAutomationAPIProvider.js
@@ -40,6 +40,7 @@ inherits(ZAutomationAPIWebRequest, ZAutomationWebRequest);
 _.extend(ZAutomationAPIWebRequest.prototype, {
     registerRoutes: function() {
         this.router.get("/status", this.ROLE.USER, this.statusReport);
+        this.router.get("/session", this.ROLE.ANONYMOUS, this.verifySession);
         this.router.post("/login", this.ROLE.ANONYMOUS, this.verifyLogin);
         this.router.get("/logout", this.ROLE.USER, this.doLogout);
         this.router.get("/notifications", this.ROLE.USER, this.exposeNotifications);
@@ -174,6 +175,24 @@ _.extend(ZAutomationAPIWebRequest.prototype, {
             }
         }
     },
+
+    // Returns user session information for the smarthome UI
+    verifySession: function() {
+        var auth = controller.auth.resolve(this.req, 2);
+        
+        if (! auth) {
+            return this.denyLogin("No valid user session found");
+        }
+        
+        console.logJS(this.controller.profiles);
+        
+        var profile = _.find(this.controller.profiles, function (profile) {
+            return profile.id === auth.user;
+        });
+        
+        return this.setLogin(profile);
+    },
+    
     verifyLogin: function() {
         var reqObj;
 

--- a/ZAutomationAPIProvider.js
+++ b/ZAutomationAPIProvider.js
@@ -188,16 +188,19 @@ _.extend(ZAutomationAPIWebRequest.prototype, {
         
         return reply;
     },
+    
     doLogout: function() {
         var reply = {
                 error: null,
                 data: null,
-                code: 500,
+                code: 400,
                 headers: null
             },
             session;
+        
+        var sessionId = this.controller.auth.getSessionId(this.req);
 
-        if (this.req.headers.ZWAYSession) {
+        if (sessionId) {
             session = this.req.headers.ZWAYSession;
 
             reply.headers = {
@@ -210,7 +213,7 @@ _.extend(ZAutomationAPIWebRequest.prototype, {
                 delete this.controller.auth.sessions[session];
             }
         } else {
-            reply.error = 'Internal server error.';
+            reply.error = 'Could not logout.';
         }
         
         return reply;

--- a/classes/AuthController.js
+++ b/classes/AuthController.js
@@ -35,10 +35,7 @@ AuthController.prototype.isAuthorized = function(myRole, requiredRole) {
     return myRole <= requiredRole;
 }
 
-AuthController.prototype.resolve = function(request, requestedRole) {
-    var role, session,
-        self = this;
-    
+AuthController.prototype.getSessionId = function(request) {
     // check if session id is specified in cookie or header
     var profileSID = request.headers['ZWAYSession'];
     if (!profileSID) {
@@ -51,8 +48,15 @@ AuthController.prototype.resolve = function(request, requestedRole) {
             }
         }
     }
+    
+    return profileSID;
+}
 
-    session = this.sessions[profileSID];
+AuthController.prototype.resolve = function(request, requestedRole) {
+    var role, session,
+        self = this;
+    
+    session = this.sessions[this.getSessionId(request)];
 
     if (!session) {
         // no session found or session expired


### PR DESCRIPTION
This PR addresses multiple issues (see also other PR in the smarthome repo)

* Smarthome UI did not do a proper logout. It only deleted the local session cookie, while keeping the identical HTTP-only cookie. Furthermore the session ID was not invalidated on the server side. 
* Previously requests to logout had to provide the ZWAYSession id via HTTP headers. Now the session ID can also be read from the cookie. (see AuthController.js getSessionId)
* Login to Smarthome UI  via local user (eg. via a NGINX proxy setup) was not possible. For this I had to refactor the verifyLogin method into smaller chucks which can be reused by a session controller, which returns the data in the format required by the SmarthomeUI
