### PR TITLE
Add an event to the bus to allow another module to react.

### DIFF
--- a/modules/SecurityMode/index.js
+++ b/modules/SecurityMode/index.js
@@ -203,6 +203,7 @@ SecurityMode.prototype.testRule = function (tree) {
 
         // Send Notification
         self.controller.addNotification("warning", self.message, "module", "SecurityMode");
+        self.controller.emit('SecurityMode.alert', self);
 
         tree.action.switches && tree.action.switches.forEach(function(devState) {
             var vDev = self.controller.devices.get(devState.device);


### PR DESCRIPTION
I'm working on a helper for our custom need. Knowing when the SecurityMode is triggered is a must.
If we can't get this thru the event bus, we will need to copy all you module only to be able to react the way we need to.
So it will make you module more versatile.¸
For example: Ask our user if they want to turn off the siren ;-) Or, the alarm may be silent and the user may have the opportunity to turn it off before it became audible.
Receiving the module as an argument will allow us to access the config and know which device(siren for example) were triggered.

Thanks !