### PR TITLE
Allowing Basic Authentication for Ajax Requests

### DIFF
--- a/WebserverRequestRouter.js
+++ b/WebserverRequestRouter.js
@@ -194,7 +194,8 @@ ZAutomationWebRequest.prototype.initResponse = function (response) {
         'Date': date.toUTCString(),
         'Access-Control-Expose-Headers': that.controller.allow_headers.join(', '),
         'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS'
+        'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+        'Access-Control-Allow-Headers': 'Authorization'
     };
     
     if (response.headers) {


### PR DESCRIPTION
Allowing Basic Authentication for Ajax Requests from remote hosts (Dealing with CORS from modern browsers)