### PR TITLE
Ignore everything but the 'on' command in LightScene

### DIFF
--- a/modules/LightScene/index.js
+++ b/modules/LightScene/index.js
@@ -41,7 +41,9 @@ LightScene.prototype.init = function (config) {
             }
         },
         overlay: {},
-        handler: function () {
+        handler: function (command) {
+            if (command !== 'on') return;
+
             self.config.switches.forEach(function(devState) {
                 var vDev = self.controller.devices.get(devState.device);
                 if (vDev) {


### PR DESCRIPTION
Performing an 'off' or 'update' command on a LightScene widget leads to the execution of the scene. This PR adds checks to the LightScene widget handler code to check for 'on' commands. If you don't accept this PR please make at least sure that the 'update' command does not trigger the scene.