### PR TITLE
Display device location in notifications and config

### DIFF
--- a/classes/AutomationController.js
+++ b/classes/AutomationController.js
@@ -1816,6 +1816,10 @@ AutomationController.prototype.generateNamespaces = function (callback, device, 
                 cutSubType = '',
                 paramEntry;
 
+            if (devLocation) {
+                devEntry.deviceName = location.title + ' - ' + devEntry.deviceName;
+            }
+
             // check for type entry
             typeEntryExists = _.filter(nspc, function(typeEntry){
                 return typeEntry.id === devTypeEntry;

--- a/modules/InbandNotifications/index.js
+++ b/modules/InbandNotifications/index.js
@@ -57,7 +57,14 @@ InbandNotifications.prototype.init = function (config) {
             var devId = vDev.get('id'),
                 devType = vDev.get('deviceType'),
                 devProbeType = vDev.get('probeType'),
+                devLocation = device.get('location'),
                 devName = vDev.get('metrics:title'),
+                if (devLocation) {
+                    location = self.controller.getLocation(self.controller.locations, devLocation),
+                    if (location) {
+                      devName = location.title + ' - ' + devName;
+                    }
+                }
                 scaleUnit = vDev.get('metrics:scaleTitle'),
                 lvl = vDev.get('metrics:level'),
                 eventType = function(){

--- a/modules/InbandNotifications/index.js
+++ b/modules/InbandNotifications/index.js
@@ -1,6 +1,6 @@
 /*** InbandNotifications Z-Way HA module *******************************************
 
-Version: 1.1.0
+Version: 1.0.6
 (c) Z-Wave.Me, 2015
 -----------------------------------------------------------------------------
 Author: Niels Roche <nir@zwave.eu>
@@ -57,14 +57,8 @@ InbandNotifications.prototype.init = function (config) {
             var devId = vDev.get('id'),
                 devType = vDev.get('deviceType'),
                 devProbeType = vDev.get('probeType'),
-                devLocation = device.get('location'),
+                devLocation = vDev.get('location'),
                 devName = vDev.get('metrics:title'),
-                if (devLocation) {
-                    location = self.controller.getLocation(self.controller.locations, devLocation),
-                    if (location) {
-                      devName = location.title + ' - ' + devName;
-                    }
-                }
                 scaleUnit = vDev.get('metrics:scaleTitle'),
                 lvl = vDev.get('metrics:level'),
                 eventType = function(){
@@ -76,6 +70,13 @@ InbandNotifications.prototype.init = function (config) {
                 },
                 createItem = 0,
                 item, msg, msgType;
+
+            if (devLocation) {
+                var location = self.controller.getLocation(self.controller.locations, devLocation);
+                if (location) {
+                  devName = location.title + ' - ' + devName;
+                }
+            }
 
             if(lastChanges.filter(function(o){
                             return o.id === devId;
@@ -120,15 +121,6 @@ InbandNotifications.prototype.init = function (config) {
                                 dev: devName,
                                 l: lvl + '%'
                                 };
-                            msgType = 'device-status';
-
-                            self.controller.addNotification('device-info', msg , msgType, devId);
-                            break;
-                        case 'sensorDiscrete':
-                            msg = {
-                                dev: devName,
-                                l: lvl
-                            };
                             msgType = 'device-status';
 
                             self.controller.addNotification('device-info', msg , msgType, devId);


### PR DESCRIPTION
Currently it is impossible to distinguish a device called "Motion" in
the room lounge from a device called "Motion" in the kitchen, forcing devices to be
called "Lounge Motion", now in the room lounge I have "Lounge Motion",
"Lounge Main Light" etc. This clutters the UI, is redundant and generally
makes no sense.

This updates the device drop downs and the notifications to include a
location if one is set.

I appreciate if users already have a Device in there lounge called
"Lounge Motion" they will now in places see a device called "Lounge -
Lounge Motion", but this is no worse that what they currently see when
looking at devices in the room lounge.