### PR TITLE
Display device location in notifications and config

### DIFF
--- a/classes/AutomationController.js
+++ b/classes/AutomationController.js
@@ -1816,6 +1816,10 @@ AutomationController.prototype.generateNamespaces = function (callback, device, 
                 cutSubType = '',
                 paramEntry;
 
+            if (devLocation) {
+                devEntry.deviceName = location.title + ' - ' + devEntry.deviceName;
+            }
+
             // check for type entry
             typeEntryExists = _.filter(nspc, function(typeEntry){
                 return typeEntry.id === devTypeEntry;

--- a/modules/InbandNotifications/index.js
+++ b/modules/InbandNotifications/index.js
@@ -58,6 +58,7 @@ InbandNotifications.prototype.init = function (config) {
                 devType = vDev.get('deviceType'),
                 devProbeType = vDev.get('probeType'),
                 devName = vDev.get('metrics:title'),
+                devLocation = vDev.get('location'),
                 scaleUnit = vDev.get('metrics:scaleTitle'),
                 lvl = vDev.get('metrics:level'),
                 eventType = function(){
@@ -69,6 +70,13 @@ InbandNotifications.prototype.init = function (config) {
                 },
                 createItem = 0,
                 item, msg, msgType;
+
+            if (devLocation) {
+                var location = self.controller.getLocation(self.controller.locations, devLocation);
+                if (location) {
+                  devName = location.title + ' - ' + devName;
+                }
+            }
 
             if(lastChanges.filter(function(o){
                             return o.id === devId;


### PR DESCRIPTION
Currently it is impossible to distinguish a device called "Motion" in the room lounge from a device called "Motion" in the kitchen, forcing devices to be called "Lounge Motion", now in the room lounge I am forced to devices named "Lounge Motion", "Lounge Main Light" etc. This clutters the UI with redundant information.

This updates the device drop downs and the notifications to include a location if one is set.

I appreciate if users already have a Device in there lounge called "Lounge Motion" they will now in places see a device called "Lounge - Lounge Motion", but this is no worse that what they currently see when looking at devices in the room lounge.