### PR TITLE
Added clouds info to metrics:zwaveOpenWeather

### DIFF
--- a/modules/OpenWeather/index.js
+++ b/modules/OpenWeather/index.js
@@ -86,8 +86,9 @@ OpenWeather.prototype.fetchExtendedWeather = function(instance) {
                 var main = res.data.main,
                     weather = res.data.weather,
                     wind = res.data.wind,
+                    clouds = res.data.clouds,
                     country = res.data.sys.country,
-                    weatherData = {'main': main,'weather': weather, 'wind': wind},
+                    weatherData = {'main': main,'weather': weather, 'wind': wind, 'clouds': clouds},
                     temp = Math.round((self.config.units === "celsius" ? main.temp - 273.15 : main.temp * 1.8 - 459.67) * 10) / 10,
                     icon = "http://openweathermap.org/img/w/" + weather[0].icon + ".png",
                     flag = "http://openweathermap.org/images/flags/" + country.toLowerCase() + ".png";


### PR DESCRIPTION
Just included cloud weather information into metrics to allow usage by other automation modules to control devices, e.g. blinds. Useful, even if not displayed in widget yet.