### PR TITLE
Update check of level to set: must be a number

### DIFF
--- a/modules/IfThen/index.js
+++ b/modules/IfThen/index.js
@@ -68,7 +68,7 @@ IfThen.prototype.init = function (config) {
 					}
 				} else {
 					var id = el[type].target,
-						lvl = el[type].status === 'level' && el[type].level? el[type].level : (el[type].status === 'color' && el[type].color? el[type].color: el[type].status),
+						lvl = el[type].status === 'level' && typeof el[type].level === 'number' ? el[type].level : (el[type].status === 'color' && el[type].color? el[type].color: el[type].status),
 						vDev = that.controller.devices.get(id),
 						// compare old and new level to avoid unneccessary updates
 						compareValues = function(valOld,valNew){


### PR DESCRIPTION
Bugfix. Level "0" won't be set with previous check as !!level evaluates to "false" for level=0. As level "0" should be a valid level to set, the level is checked to be a number now.